### PR TITLE
Fix 5_1 and 5_3

### DIFF
--- a/Exercises/ex5_1.md
+++ b/Exercises/ex5_1.md
@@ -115,7 +115,7 @@ kinds of input sources.  For example:
 ```python
 >>> import gzip
 >>> import stock
->>> file = gzip.open('Data/portfolio.csv.gz')
+>>> file = gzip.open('Data/portfolio.csv.gz', 'rt')
 >>> port = reader.csv_as_instances(file, stock.Stock)
 >>> port
 [Stock('AA', 100, 32.2), Stock('IBM', 50, 91.1), Stock('CAT', 150, 83.44), 

--- a/Exercises/soln5_3.md
+++ b/Exercises/soln5_3.md
@@ -48,11 +48,10 @@ def read_csv_as_instances(filename, cls, *, headers=None):
 import csv
 
 def convert_csv(lines, converter, *, headers=None):
-    records = []
     rows = csv.reader(lines)
     if headers is None:
         headers = next(rows)
-    return map(lambda row: converter(headers, row), rows)
+    return list(map(lambda row: converter(headers, row), rows))
 ```
 
 

--- a/Solutions/5_3/reader.py
+++ b/Solutions/5_3/reader.py
@@ -9,12 +9,15 @@ def convert_csv(lines, converter, *, headers=None):
     return list(map(lambda row: converter(headers, row), rows))
 
 def csv_as_dicts(lines, types, *, headers=None):
-    return convert_csv(lines, 
-                       lambda headers, row: { name: func(val) for name, func, val in zip(headers, types, row) })
+    return convert_csv(lines,
+                       lambda headers, row: {name: func(val) for name, func, val in zip(headers, types, row)},
+                       headers=headers)
+
 
 def csv_as_instances(lines, cls, *, headers=None):
     return convert_csv(lines,
-                       lambda headers, row: cls.from_row(row))
+                       lambda headers, row: cls.from_row(row),
+                       headers=headers)
 
 def read_csv_as_dicts(filename, types, *, headers=None):
     '''


### PR DESCRIPTION
This PR fixes some typos in exercises 5_1 and 5_3, these are:
* Missing text mode in gzip open
    <img width="944" alt="typo_5_1" src="https://github.com/dabeaz-course/python-mastery/assets/29715691/fb7e6a32-429b-47b2-aecf-58d57cd29543">

* Solution of 5.3 wasn’t using the `headers` kwarg
    <img width="944" alt="typo_5_3" src="https://github.com/dabeaz-course/python-mastery/assets/29715691/554c58c7-5e76-4da9-8557-f3f00e03108e">
* Updated the `soln5_3.md` to use list as the solution does