### PR TITLE
Update ex5_6.md to fix NameError in example code

### DIFF
--- a/Exercises/ex5_6.md
+++ b/Exercises/ex5_6.md
@@ -25,7 +25,7 @@ import stock
 
 class TestStock(unittest.TestCase):
     def test_create(self):
-        s = Stock('GOOG', 100, 490.1)
+        s = stock.Stock('GOOG', 100, 490.1)
         self.assertEqual(s.name, 'GOOG')
         self.assertEqual(s.shares, 100)
         self.assertEqual(s.price, 490.1)


### PR DESCRIPTION
Calling Stock() directly without providing the name of the module will result in the following error:

NameError: name 'Stock' is not defined

This fixes the bug in the example code.