### PR TITLE
Update ex6_2.md to fix variable mismatch

### DIFF
--- a/Exercises/ex6_2.md
+++ b/Exercises/ex6_2.md
@@ -160,7 +160,7 @@ class Stock(Structure):
     def cost(self):
         return self.shares * self.price
 
-    def sell(self, nshares):
+    def sell(self, shares):
         self.shares -= shares
 ```
 


### PR DESCRIPTION
The sell() method takes the nshares argument, however inside the method the variable shares is used instead.

This patch changes the name of the argument according to the variable used within the method.