### PR TITLE
fix ValueError in f_locals.pop('self') Python 3.13+

### DIFF
--- a/Exercises/ex6_2.md
+++ b/Exercises/ex6_2.md
@@ -61,8 +61,9 @@ and class definitions:
 
 ```python
 >>> def _init(locs):
-        self = locs.pop('self')
+        self = locs['self']
         for name, val in locs.items():
+            if name == 'self': continue
             setattr(self, name, val)
 
 >>> class Stock:
@@ -96,8 +97,9 @@ frame hacking.  Try this variant of the `_init()` function:
 >>> import sys
 >>> def _init():
         locs = sys._getframe(1).f_locals   # Get callers local variables
-        self = locs.pop('self')
+        self = locs['self']
         for name, val in locs.items():
+            if name == 'self': continue
             setattr(self, name, val)
 >>>
 ```
@@ -135,8 +137,9 @@ class Structure:
     @staticmethod
     def _init():
         locs = sys._getframe(1).f_locals
-        self = locs.pop('self')
+        self = locs['self']
         for name, val in locs.items():
+            if name == 'self': continue
             setattr(self, name, val)
     ...
 ```

--- a/Exercises/soln6_2.md
+++ b/Exercises/soln6_2.md
@@ -11,8 +11,9 @@ class Structure:
     @staticmethod
     def _init():
         locs = sys._getframe(1).f_locals
-        self = locs.pop('self')
+        self = locs['self']
         for name, val in locs.items():
+            if name == 'self': continue
             setattr(self, name, val)
 
     def __setattr__(self, name, value):

--- a/Exercises/soln6_3.md
+++ b/Exercises/soln6_3.md
@@ -12,8 +12,9 @@ class Structure:
     @staticmethod
     def _init():
         locs = sys._getframe(1).f_locals
-        self = locs.pop('self')
+        self = locs['self']
         for name, val in locs.items():
+            if name == 'self': continue
             setattr(self, name, val)
 
     def __setattr__(self, name, value):

--- a/Solutions/6_2/structure.py
+++ b/Solutions/6_2/structure.py
@@ -8,8 +8,9 @@ class Structure:
     @staticmethod
     def _init():
         locs = sys._getframe(1).f_locals
-        self = locs.pop('self')
+        self = locs['self']
         for name, val in locs.items():
+            if name == 'self': continue
             setattr(self, name, val)
 
     def __setattr__(self, name, value):

--- a/Solutions/6_3/structure.py
+++ b/Solutions/6_3/structure.py
@@ -9,8 +9,9 @@ class Structure:
     @staticmethod
     def _init():
         locs = sys._getframe(1).f_locals
-        self = locs.pop('self')
+        self = locs['self']
         for name, val in locs.items():
+            if name == 'self': continue
             setattr(self, name, val)
 
     def __setattr__(self, name, value):


### PR DESCRIPTION
The error
ValueError: cannot remove local variables from FrameLocalsProxy

is caused by PEP 667 – Consistent views of namespaces peps.python.org/pep-0667
implemented in Python 3.13